### PR TITLE
Fix Windows path bug + ENAMETOOLONG bypass

### DIFF
--- a/editors/code/package-lock.json
+++ b/editors/code/package-lock.json
@@ -96,7 +96,7 @@
     },
     "node_modules/@hpcc-js/wasm": {
       "version": "1.20.1",
-      "resolved": "https://registry.npmmirror.com/@hpcc-js/wasm/-/wasm-1.20.1.tgz",
+      "resolved": "https://registry.npmjs.org/@hpcc-js/wasm/-/wasm-1.20.1.tgz",
       "integrity": "sha512-M1Blw6CdDkiurEmUTDFf7DDOVXOVblSKHBcc/+pUiBj2lIXgxkVOZhIm54zNspQdpurv7KKJ7VbylYMQRm4IyQ==",
       "dependencies": {
         "yargs": "17.6.0"

--- a/editors/code/src/extension.ts
+++ b/editors/code/src/extension.ts
@@ -89,7 +89,9 @@ export async function activate(context: vscode.ExtensionContext) {
 			const include = new vscode.RelativePattern(folder, `{${paths.join(',')}}`);
 			const exclude = `{${ignores.join(',')}}`;
 
-			return generator.generateCallGraph(selectedFiles, include, exclude);
+			let search = scanDirectories.length > 0;
+
+			return generator.generateCallGraph(selectedFiles, include, exclude, search);
 		})
 		.then(svg => showCallGraph(context, svg));
 	});


### PR DESCRIPTION
This fixes a pathing issue in Windows that causes edges to not be drawn. The drive letter in paths coming from the selector or directory search is lower case while the drive letter from call hierarchy is upper case. The solution here is to just capitalize the drive letter from the selector / directory search. 

Additionally a bypass to the ENAMETOOLONG issue for very large projects by not searching if the user only selects files and no directories.  